### PR TITLE
Handle HSYNC at the end of the frame.

### DIFF
--- a/decoder/source/trc_frame_deformatter.cpp
+++ b/decoder/source/trc_frame_deformatter.cpp
@@ -615,6 +615,17 @@ bool TraceFmtDcdImpl::extractFrame()
             buf_left -= 2;
             dataPtr += 2;
         }
+        if (hasHSyncs && (buf_left > 2))
+        {
+            // We may have HSYNC at the end of the frame.
+            // It will appear as a HSYNC at the beginning of the next frame.
+            // We set the flag, so this should be taken care of.
+            data_pair_val = *((uint16_t*)(dataPtr));
+            if (*(uint16_t*)(dataPtr) == HSYNC_PATTERN)
+            {
+                m_b_fsync_start_eob = true;
+            }
+        }
     }
 
     // total bytes processed this pass 


### PR DESCRIPTION
Handle HSYNC at the end of the frame. Vitra-XS can add HSYNC at any place, including after the frame to be able to flush the data to the host.